### PR TITLE
Concurrency, transfer to ba-st, fixed dependencies versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,3 @@ matrix:
   - smalltalk: Pharo64-7.0
   - smalltalk: Pharo-7.0
   fast_finish: true
-before_deploy:
-  - cp "${SMALLTALK_CI_IMAGE}" "<PROJECT_NAME>.image"
-  - cp "${SMALLTALK_CI_CHANGES}" "<PROJECT_NAME>.changes"
-  - zip -q "${TRAVIS_BRANCH}-${TRAVIS_SMALLTALK_VERSION}.zip" "<PROJECT_NAME>.image" "<PROJECT_NAME>.changes"
-deploy:
-  provider: releases
-  api_key:
-    secure: XXX (Use travis setup releases to configure it)
-  file: "${TRAVIS_BRANCH}-${TRAVIS_SMALLTALK_VERSION}.zip"
-  skip_cleanup: true
-  on:
-    repo: fortizpenaloza/Kepler-Document-Persistence
-    tags: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ There's several ways to contribute to the project: reporting bugs, sending feedb
 
 ## Reporting issues
 
-You can report issues [here](https://github.com/fortizpenaloza/Kepler-Document-Persistence/issues/new)
+You can report issues [here](https://github.com/ba-st/Kepler-MongoDB/issues/new)
 
 ## Contributing Code
 - This project is MIT licensed, so any code contribution MUST be under the same license.

--- a/README.md
+++ b/README.md
@@ -6,15 +6,14 @@
     <a href="docs/"><strong>Explore the docs »</strong></a>
     <br>
     <br>
-    <a href="https://github.com/fortizpenaloza/Kepler-Document-Persistence/issues/new?labels=Type%3A+Defect">Report a defect</a>
+    <a href="https://github.com/ba-st/Kepler-MongoDB/issues/new?labels=Type%3A+Defect">Report a defect</a>
     |
-    <a href="https://github.com/fortizpenaloza/Kepler-Document-Persistence/issues/new?labels=Type%3A+Feature">Request feature</a>
+    <a href="https://github.com/ba-st/Kepler-MongoDB/issues/new?labels=Type%3A+Feature">Request feature</a>
   </p>
 </p>
 
-[![GitHub release](https://img.shields.io/github/release/fortizpenaloza/Kepler-Document-Persistence.svg)](https://github.com/fortizpenaloza/Kepler-Document-Persistence/releases/latest)
-[![Build Status](https://travis-ci.com/fortizpenaloza/Kepler-Document-Persistence.svg?branch=master)](https://travis-ci.org/fortizpenaloza/Kepler-Document-Persistence)
-[![Coverage Status](https://coveralls.io/repos/github/fortizpenaloza/Kepler-Document-Persistence/badge.svg?branch=master)](https://coveralls.io/github/fortizpenaloza/Kepler-Document-Persistence?branch=master)
+[![Build Status](https://travis-ci.com/ba-st/Kepler-MongoDB.svg?branch=master)](https://travis-ci.org/ba-st/Kepler-MongoDB)
+[![Coverage Status](https://coveralls.io/repos/github/ba-st/Kepler-MongoDB/badge.svg?branch=master)](https://coveralls.io/github/ba-st/Kepler-MongoDB?branch=master)
 
 Why would I care about this thing? When to use, for whom is designed, when not to use.
 
@@ -25,7 +24,7 @@ Why would I care about this thing? When to use, for whom is designed, when not t
 ## Quick Start
 
 - Download the latest [Pharo 32](https://get.pharo.org/) or [64 bits VM](https://get.pharo.org/64/).
-- Download a ready to use image from the [release page](https://github.com/fortizpenaloza/Kepler-Document-Persistence/releases/latest)
+- Download a ready to use image from the [release page](https://github.com/ba-st/Kepler-MongoDB/releases/latest)
 - Explore the [documentation](docs/)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Why would I care about this thing? When to use, for whom is designed, when not t
 ## Quick Start
 
 - Download the latest [Pharo 32](https://get.pharo.org/) or [64 bits VM](https://get.pharo.org/64/).
-- Download a ready to use image from the [release page](https://github.com/ba-st/Kepler-MongoDB/releases/latest)
 - Explore the [documentation](docs/)
 
 ## Installation

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -6,7 +6,7 @@ You can load **Kepler document persistence** evaluating:
 ```smalltalk
 Metacello new
 	baseline: 'KeplerDocumentPersistence';
-	repository: 'github://fortizpenaloza/Kepler-Document-Persistence:master/source';
+	repository: 'github://ba-st/Kepler-MongoDB:master/source';
 	load.
 ```
 >  Change `master` to some released version if you want a pinned version
@@ -21,7 +21,7 @@ setUpDependencies: spec
 	spec
 		baseline: 'KeplerDocumentPersistence'
 			with: [ spec
-				repository: 'github://fortizpenaloza/Kepler-Document-Persistence:v{XX}/source';
+				repository: 'github://ba-st/Kepler-MongoDB:v{XX}/source';
 				loads: #('Deployment') ];
 		import: 'KeplerDocumentPersistence'.
 ```

--- a/source/BaselineOfKeplerDocumentPersistence/BaselineOfKeplerDocumentPersistence.class.st
+++ b/source/BaselineOfKeplerDocumentPersistence/BaselineOfKeplerDocumentPersistence.class.st
@@ -55,6 +55,6 @@ BaselineOfKeplerDocumentPersistence >> setUpDependencies: spec [
 	spec
 		baseline: 'MongoTalk'
 		with: [ spec
-				repository: 'github://pharo-nosql/mongotalk:v1.15/mc';
+				repository: 'github://pharo-nosql/mongotalk:1.15/mc';
 				loads: #('Core' 'Tools') ]
 ]

--- a/source/BaselineOfKeplerDocumentPersistence/BaselineOfKeplerDocumentPersistence.class.st
+++ b/source/BaselineOfKeplerDocumentPersistence/BaselineOfKeplerDocumentPersistence.class.st
@@ -48,13 +48,13 @@ BaselineOfKeplerDocumentPersistence >> setUpDependencies: spec [
 	spec
 		baseline: 'Kepler'
 		with: [ spec
-				repository: 'github://ba-st/Kepler:master/source';
+				repository: 'github://ba-st/Kepler:v2.0.0/source';
 				loads: #('Deployment' 'SystemBasedTests') ].
 	spec import: 'Kepler'.
 
 	spec
 		baseline: 'MongoTalk'
 		with: [ spec
-				repository: 'github://pharo-nosql/mongotalk:master/mc';
+				repository: 'github://pharo-nosql/mongotalk:v1.15/mc';
 				loads: #('Core' 'Tools') ]
 ]

--- a/source/Kepler-Document-Persistence/MongoDBBasedPersistenceSystem.class.st
+++ b/source/Kepler-Document-Persistence/MongoDBBasedPersistenceSystem.class.st
@@ -2,7 +2,9 @@ Class {
 	#name : #MongoDBBasedPersistenceSystem,
 	#superclass : #DocumentPersistenceSystem,
 	#instVars : [
-		'database'
+		'database',
+		'collections',
+		'dbMutex'
 	],
 	#category : #'Kepler-Document-Persistence'
 }
@@ -22,38 +24,43 @@ MongoDBBasedPersistenceSystem class >> using: aDatabase [
 { #category : #adding }
 MongoDBBasedPersistenceSystem >> add: aDocument onCollectionNamed: aName [
 
-	| collection | 
-	
-	collection := database getCollection: aName.
-	collection add: aDocument
+	dbMutex critical: [ (self cachedCollection: aName) add: aDocument ]
+]
+
+{ #category : #private }
+MongoDBBasedPersistenceSystem >> cachedCollection: aName [
+
+	^ collections at: aName ifAbsentPut: [ MongoCollection database: database name: aName ]
 ]
 
 { #category : #querying }
 MongoDBBasedPersistenceSystem >> collectionNamed: aName [
 
-	^ (database getCollection: aName)
-		query: [ :query | 
-			query
-				fields: {('_id' -> 0)} asDictionary;
-				order: {('date' -> 1)} asDictionary;
-				yourself ]
+	^ dbMutex
+		critical: [ (self cachedCollection: aName)
+				query: [ :query | 
+					query
+						fields: {('_id' -> 0)} asDictionary;
+						order: {('date' -> 1)} asDictionary;
+						yourself ] ]
 ]
 
 { #category : #initialization }
 MongoDBBasedPersistenceSystem >> initializeUsing: aDatabase [
 
 	super initialize.
-	database := aDatabase 
+	database := aDatabase.
+	collections := Dictionary new.
+	dbMutex := Semaphore forMutualExclusion
 ]
 
 { #category : #querying }
 MongoDBBasedPersistenceSystem >> oneDocumentFilteredBy: aBlock onCollectionNamed: aCollectionName ifFound: aFoundBlock ifNone: aNoneBlock [
 
-	| collection document |
+	| document |
 
-	collection := database getCollection: aCollectionName.
-	document := collection detect: aBlock.
-	document ifNil: aNoneBlock ifNotNil: [ aFoundBlock value: document ]
+	document := dbMutex critical: [ (self cachedCollection: aCollectionName) detect: aBlock ].
+	^ document ifNil: aNoneBlock ifNotNil: aFoundBlock
 ]
 
 { #category : #'dependency resolution' }
@@ -65,8 +72,5 @@ MongoDBBasedPersistenceSystem >> resolveDependecies [
 { #category : #updating }
 MongoDBBasedPersistenceSystem >> update: aDocumentToBeUpdated with: aDocument onCollectionNamed: aName [
 
-	| collection | 
-	
-	collection := database getCollection: aName.
-	collection update: aDocumentToBeUpdated with: aDocument
+	dbMutex critical: [ (self cachedCollection: aName) update: aDocumentToBeUpdated with: aDocument ]
 ]


### PR DESCRIPTION
- Using a semaphore to avoid concurrency problems, not a definitive solution, but works for now. Should be changed to a connection pool later.
- Changed references to the old repository to ba-st.
- Changed dependencies to use a fixed version, not master.